### PR TITLE
Update for compatibility with recent versions of ActiveRecord / Money gems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ class CreateDoubleDouble < ActiveRecord::Migration
     end
     add_index :double_double_accounts, [:name, :type]
 
-    create_table :double_double_transactions do |t|
+    create_table :double_double_entries do |t|
       t.string :description
       t.references :initiator,        polymorphic: true
-      t.references :transaction_type
+      t.references :entry_type
       t.timestamps
     end
-    add_index :double_double_transactions, :initiator_id
-    add_index :double_double_transactions, :initiator_type
-    add_index :double_double_transactions, :transaction_type_id
+    add_index :double_double_entries, :initiator_id
+    add_index :double_double_entries, :initiator_type
+    add_index :double_double_entries, :entry_type_id
 
-    create_table :double_double_transaction_types do |t|
+    create_table :double_double_entry_types do |t|
       t.string :description,    null: false
     end
-    add_index :double_double_transaction_types, :description
+    add_index :double_double_entry_types, :description
 
     create_table :double_double_amounts do |t|
       t.string :type
       t.references :account
-      t.references :transaction
+      t.references :entry
       t.references :context,    polymorphic: true
       t.references :subcontext, polymorphic: true
       t.references :accountee,  polymorphic: true
@@ -72,8 +72,8 @@ class CreateDoubleDouble < ActiveRecord::Migration
     add_index :double_double_amounts, :accountee_id
     add_index :double_double_amounts, :accountee_type
     add_index :double_double_amounts, :type
-    add_index :double_double_amounts, [:account_id, :transaction_id]
-    add_index :double_double_amounts, [:transaction_id, :account_id]
+    add_index :double_double_amounts, [:account_id, :entry_id]
+    add_index :double_double_amounts, [:entry_id, :account_id]
   end
 end
 ```
@@ -96,7 +96,7 @@ As with many off-the-shelf accounting systems, this project supports:
 
 ### Accounts
 
-All accounts created in a double-entry system make up the [chart of accounts][3].  This collection of accounts will determine how money is tracked as it moves through the system.  It is important to design and create the chart of accounts prior to creating transactions.  *If we want people to hold "an individual account" in this system, we will configure them as an accountee, not with a new account.  __See the section on accountees__ *
+All accounts created in a double-entry system make up the [chart of accounts][3].  This collection of accounts will determine how money is tracked as it moves through the system.  It is important to design and create the chart of accounts prior to creating entries.  *If we want people to hold "an individual account" in this system, we will configure them as an accountee, not with a new account.  __See the section on accountees__ *
 
 [3]: http://en.wikipedia.org/wiki/Chart_of_accounts
 
@@ -144,9 +144,9 @@ DoubleDouble::Asset.create! name:'Cash', number: 11
 DoubleDouble::Liability.create! name:'Grandpa Loan', number: 12
 DoubleDouble::Expense.create! name:'Spending', number: 13
 ```
-Grandpa was kind enough to loan us $800 USD in cash for college textbooks.  To enter this we will require a transaction which will affect both 'Cash' and 'Grandpa Loan'
+Grandpa was kind enough to loan us $800 USD in cash for college textbooks.  To enter this we will require a entry which will affect both 'Cash' and 'Grandpa Loan'
 ```ruby
-DoubleDouble::Transaction.create!(
+DoubleDouble::Entry.create!(
   description: 
     'We received a loan from Grandpa',
   debits:[
@@ -157,7 +157,7 @@ DoubleDouble::Transaction.create!(
 We buy our college textbooks.
 
 ```ruby
-DoubleDouble::Transaction.create!(
+DoubleDouble::Entry.create!(
   description: 
     'Purchase textbooks from bookstore',
   debits:[
@@ -172,7 +172,7 @@ DoubleDouble::Account.named('Cash').balance.to_s           # => "320.00"
 ```
 We deceided that we wanted to return $320 of the loan.
 ```ruby
-DoubleDouble::Transaction.create!(
+DoubleDouble::Entry.create!(
   description: 
     'Payed back $320 to Grandpa',
   debits:[

--- a/double_double.gemspec
+++ b/double_double.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency 'money', '~> 5.1'
-  gem.add_dependency 'activerecord',  '~> 3.2.11'
+  gem.add_dependency 'activerecord',  '~> 4.2'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', '~> 2.12'
   gem.add_development_dependency 'factory_girl'

--- a/double_double.gemspec
+++ b/double_double.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.2'
 
   gem.add_dependency 'money'
+  gem.add_dependency 'monetize'
   gem.add_dependency 'activerecord'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', '~> 2.12'

--- a/double_double.gemspec
+++ b/double_double.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.2'
 
-  gem.add_dependency 'money', '~> 5.1'
-  gem.add_dependency 'activerecord',  '~> 4.2'
+  gem.add_dependency 'money'
+  gem.add_dependency 'activerecord'
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', '~> 2.12'
   gem.add_development_dependency 'factory_girl'

--- a/lib/double_double.rb
+++ b/lib/double_double.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'money'
+require 'monetize'
 
 require 'double_double/version'
 
@@ -18,6 +19,6 @@ require 'double_double/amount'
 require 'double_double/credit_amount'
 require 'double_double/debit_amount'
 
-# Transactions
-require 'double_double/transaction'
-require 'double_double/transaction_type'
+# entries
+require 'double_double/entry'
+require 'double_double/entry_type'

--- a/lib/double_double/credit_amount.rb
+++ b/lib/double_double/credit_amount.rb
@@ -1,5 +1,5 @@
 module DoubleDouble
-  # The CreditAmount class represents credit entries in the transaction journal.
+  # The CreditAmount class represents credit entries in the entry journal.
   #
   # @example
   #     credit_amount = DoubleDouble::CreditAmount.new(account: "revenue", amount: 1000)

--- a/lib/double_double/debit_amount.rb
+++ b/lib/double_double/debit_amount.rb
@@ -1,5 +1,5 @@
 module DoubleDouble
-  # The DebitAmount class represents debit entries in the transaction journal.
+  # The DebitAmount class represents debit entries in the entry journal.
   #
   # @example
   #     debit_amount = DoubleDouble::DebitAmount.new(account: "cash", amount: 1000)

--- a/lib/double_double/entry_type.rb
+++ b/lib/double_double/entry_type.rb
@@ -1,14 +1,13 @@
 module DoubleDouble
-  class TransactionType < ActiveRecord::Base
-    self.table_name = 'double_double_transaction_types'
+  class EntryType < ActiveRecord::Base
+    self.table_name = 'double_double_entry_types'
     
-    has_many :transactions
-    attr_accessible :description
+    has_many :entries
 
     validates :description, length: { minimum: 6 }, presence: true, uniqueness: true
 
     def self.of description_given
-      TransactionType.where(description: description_given.to_s).first
+      EntryType.where(description: description_given.to_s).first
     end
 
     def to_s
@@ -16,7 +15,7 @@ module DoubleDouble
     end
   end
 
-  class UnassignedTransactionType
+  class UnassignedEntryType
     class << self
       def description
         'unassigned'

--- a/spec/factories/transaction_factory.rb
+++ b/spec/factories/transaction_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
-  factory :transaction, class: DoubleDouble::Transaction do
-    description { FactoryGirl.generate(:transaction_type_description) }
+  factory :entry, class: DoubleDouble::Entry do
+    description { FactoryGirl.generate(:entry_type_description) }
   end
 
-  sequence :transaction_description do |n|
-    "transaction description #{n}"
+  sequence :entry_description do |n|
+    "entry description #{n}"
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -29,7 +29,7 @@ module DoubleDouble
       Account.trial_balance.should be_kind_of(Money)
     end
 
-    it "should report a trial balance of 0 with correct transactions (with a contrived example of transactions)" do
+    it "should report a trial balance of 0 with correct entries (with a contrived example of entries)" do
       # credit accounts
       FactoryGirl.create(:liability, name: 'liability acct')
       FactoryGirl.create(:equity,    name: 'equity acct')
@@ -42,24 +42,24 @@ module DoubleDouble
       FactoryGirl.create(:liability, name: 'contra liability acct', :contra => true)
       FactoryGirl.create(:equity,    name: 'contra equity acct',    :contra => true)
       FactoryGirl.create(:revenue,   name: 'contra revenue acct',   :contra => true)
-      Transaction.create!(
-        description: 'spec transaction 01',
+      Entry.create!(
+        description: 'spec entry 01',
         debits:  [{account: 'liability acct', amount: 100_000}],
         credits: [{account: 'asset acct',     amount: 100_000}])
-      Transaction.create!(
-        description: 'spec transaction 02',
+      Entry.create!(
+        description: 'spec entry 02',
         debits:  [{account: 'equity acct',  amount: 1_000}],
         credits: [{account: 'expense acct', amount: 1_000}])
-      Transaction.create!(
-        description: 'spec transaction 03',
+      Entry.create!(
+        description: 'spec entry 03',
         debits:  [{account: 'revenue acct',          amount: 40_404}],
         credits: [{account: 'contra liability acct', amount: 40_404}])
-      Transaction.create!(
-        description: 'spec transaction 04',
+      Entry.create!(
+        description: 'spec entry 04',
         debits:  [{account: 'contra asset acct',  amount: 2}], 
         credits: [{account: 'contra equity acct', amount: 2}])
-      Transaction.create!(
-        description: 'spec transaction 05',
+      Entry.create!(
+        description: 'spec entry 05',
         debits:  [{account: 'contra expense acct', amount: 333}], 
         credits: [{account: 'contra revenue acct', amount: 333}])
       Account.trial_balance.should eq(0)

--- a/spec/models/debit_amount_spec.rb
+++ b/spec/models/debit_amount_spec.rb
@@ -4,7 +4,7 @@ module DoubleDouble
     before(:each) do
       @cash = DoubleDouble::Asset.create!(name:'Cash', number: 11)
       @loan = DoubleDouble::Liability.create!(name:'Loan', number: 12)
-      @dummy_transaction = DoubleDouble::Transaction.new
+      @dummy_entry = DoubleDouble::Entry.new
       @job = DoubleDouble::Expense.create!(name: 'stand-in job', number: 999)
       @po  = DoubleDouble::Expense.create!(name: 'stand-in purchase order', number: 333)
       @item_foo = DoubleDouble::Expense.create!(name: 'stand-in item_foo', number: 1000)
@@ -12,28 +12,26 @@ module DoubleDouble
     end
 
     it "should not be valid without an amount" do
-      expect {
-        c = DoubleDouble::DebitAmount.new
-        c.amount = nil
-        c.account = @cash
-        c.transaction = @dummy_transaction
-        c.save!
-      }.to raise_error(ArgumentError)
+      c = DoubleDouble::DebitAmount.new
+      c.amount = nil
+      c.account = @cash
+      c.entry = @dummy_entry
+      c.should_not be_valid
     end
 
     it "should not be valid with an amount of 0" do
       c = DoubleDouble::DebitAmount.new
       c.amount = 0
       c.account = @cash
-      c.transaction = @dummy_transaction
+      c.entry = @dummy_entry
       c.should_not be_valid
     end
 
-    it "should not be valid without a transaction" do
+    it "should not be valid without a entry" do
       c = DoubleDouble::DebitAmount.new
       c.amount = 9
       c.account = @cash
-      c.transaction = nil
+      c.entry = nil
       c.should_not be_valid
     end
 
@@ -41,43 +39,43 @@ module DoubleDouble
       c = DoubleDouble::DebitAmount.new
       c.amount = 9
       c.account = nil
-      c.transaction = @dummy_transaction
+      c.entry = @dummy_entry
       c.should_not be_valid
     end
     
     it "should be sensitive to 'context' when calculating balances, if supplied" do
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar1',
           debits:  [{account: 'Cash', amount: 123, context: @job}], 
           credits: [{account: 'Loan', amount: 123}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar2',
           debits:  [{account: 'Cash', amount: 321, context: @job}], 
           credits: [{account: 'Loan', amount: 321}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar3',
           debits:  [{account: 'Cash', amount: 275, context: @po}], 
           credits: [{account: 'Loan', amount: 275}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar4',
           debits:  [{account: 'Cash', amount: 999}], 
           credits: [{account: 'Loan', amount: 999}])
       @cash.debits_balance({context: @job}).should == 123 + 321
       @cash.debits_balance({context: @po}).should == 275
       @cash.debits_balance.should == 123 + 321 + 275 + 999
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar5',
           debits:  [{account: 'Cash', amount: 9_999, context: @job, subcontext: @item_foo}], 
           credits: [{account: 'Loan', amount: 9_999}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar5',
           debits:  [{account: 'Cash', amount: 123, context: @po, subcontext: @item_foo}], 
           credits: [{account: 'Loan', amount: 123}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar6',
           debits:  [{account: 'Cash', amount: 222, context: @po, subcontext: @item_foo}], 
           credits: [{account: 'Loan', amount: 222}])
-      Transaction.create!(
+      Entry.create!(
           description: 'Foobar7',
           debits:  [{account: 'Cash', amount: 1, context: @po, subcontext: @item_bar}], 
           credits: [{account: 'Loan', amount: 1}])

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,5 +1,5 @@
 module DoubleDouble
-  describe Transaction do
+  describe Entry do
 
     before(:each) do
       @cash = DoubleDouble::Asset.create!(name:'Cash_11', number: 1011)
@@ -14,47 +14,47 @@ module DoubleDouble
 
     it_behaves_like "it can run the README scenarios"
 
-    it 'should create a Transaction using the create! method' do
+    it 'should create a Entry using the create! method' do
       -> {
-        Transaction.create!(
-          description: 'spec transaction 01',
+        Entry.create!(
+          description: 'spec entry 01',
           debits:  [{account: 'Cash_11', amount: 10}],
           credits: [{account: 'Loan_12', amount:  9},
                     {account: 'Loan_12', amount:  1}])
-      }.should change(DoubleDouble::Transaction, :count).by(1)
+      }.should change(DoubleDouble::Entry, :count).by(1)
     end
 
-    it 'should not create a Transaction using the build method' do
+    it 'should not create a Entry using the build method' do
       -> {
-        Transaction.build(
-          description: 'spec transaction 01',
+        Entry.build(
+          description: 'spec entry 01',
           debits:  [{account: 'Cash_11', amount: 100_000}],
           credits: [{account: 'Loan_12', amount: 100_000}])
-      }.should change(DoubleDouble::Transaction, :count).by(0)
+      }.should change(DoubleDouble::Entry, :count).by(0)
     end
 
     it 'should not be valid without a credit amount' do
       # No credit_amount element
-      t1 = Transaction.build(
-        description: 'spec transaction 01',
+      t1 = Entry.build(
+        description: 'spec entry 01',
         debits:  [{account: 'Cash_11', amount: 100_000}])
       t1.should_not be_valid
-      t1.errors['base'].should include('Transaction must have at least one credit amount')
+      t1.errors['base'].should include('Entry must have at least one credit amount')
       t1.errors['base'].should include('The credit and debit amounts are not equal')
       # An empty credit_amount element
-      t2 = Transaction.build(
-        description: 'spec transaction 01',
+      t2 = Entry.build(
+        description: 'spec entry 01',
         debits:  [{account: 'Cash_11', amount: 100_000}],
         credits: [])
       t2.should_not be_valid
-      t2.errors['base'].should include('Transaction must have at least one credit amount') 
+      t2.errors['base'].should include('Entry must have at least one credit amount')
       t2.errors['base'].should include('The credit and debit amounts are not equal')
     end
 
     it 'should raise a RecordInvalid without a credit amount' do
       -> {
-      Transaction.create!(
-        description: 'spec transaction 01',
+      Entry.create!(
+        description: 'spec entry 01',
         debits:  [{account: 'Cash_11', amount: 100_000}],
         credits: [])
       }.should raise_error(ActiveRecord::RecordInvalid)
@@ -62,42 +62,42 @@ module DoubleDouble
 
     it 'should not be valid with an invalid credit amount' do
       -> {
-        Transaction.create!(
-          description: 'spec transaction 01',
+        Entry.create!(
+          description: 'spec entry 01',
           credits: [{account: 'Loan_12', amount: nil}],
           debits:  [{account: 'Cash_11', amount: 100_000}])
-      }.should raise_error(ArgumentError)
+      }.should raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'should not be valid without a debit amount' do
       # No credit_amount element
-      t1 = Transaction.build(
-        description: 'spec transaction 01',
+      t1 = Entry.build(
+        description: 'spec entry 01',
         credits:  [{account: 'Loan_12', amount: 100_000}])
       t1.should_not be_valid
-      t1.errors['base'].should include('Transaction must have at least one debit amount')
+      t1.errors['base'].should include('Entry must have at least one debit amount')
       t1.errors['base'].should include('The credit and debit amounts are not equal')
       # An empty credit_amount element
-      t2 = Transaction.build(
-        description: 'spec transaction 01',
+      t2 = Entry.build(
+        description: 'spec entry 01',
         credits: [{account: 'Loan_12', amount: 100_000}],
         debits:  [])
       t2.should_not be_valid
-      t2.errors['base'].should include('Transaction must have at least one debit amount')
+      t2.errors['base'].should include('Entry must have at least one debit amount')
       t2.errors['base'].should include('The credit and debit amounts are not equal')
     end
 
     it 'should not be valid with an invalid debit amount' do
       -> {
-        Transaction.create!(
-          description: 'spec transaction 01',
+        Entry.create!(
+          description: 'spec entry 01',
           credits: [{account: 'Cash_11', amount: 100_000}],
           debits:  [{account: 'Loan_12', amount: nil}])
-      }.should raise_error(ArgumentError)
+      }.should raise_error(ActiveRecord::RecordInvalid)
     end
 
     it 'should not be valid without a description' do
-      t = Transaction.build(
+      t = Entry.build(
           description: '',
           debits:  [{account: 'Cash_11', amount: 100_000}],
           credits: [{account: 'Loan_12', amount: 100_000}])
@@ -106,78 +106,78 @@ module DoubleDouble
     end
 
     it 'should require the debit and credit amounts to cancel' do
-      t = Transaction.build(
-        description: 'spec transaction 01',
+      t = Entry.build(
+        description: 'spec entry 01',
         credits: [{account: 'Cash_11', amount: 100_000}],
         debits:  [{account: 'Loan_12', amount:  99_999}])
       t.should_not be_valid
       t.errors['base'].should == ['The credit and debit amounts are not equal']
     end
 
-    describe 'transaction reversing' do
-      it "should negate the same non-reversed transaction" do
+    describe 'entry reversing' do
+      it "should negate the same non-reversed entry" do
         args_normal = {description: 'reverse test',
           debits:  [{account: 'Cash_11', amount: 10}],
           credits: [{account: 'Loan_12', amount:  9},
                     {account: 'Loan_12', amount:  1}]}
         args_reversed = args_normal.merge({reversed: true})
-        Transaction.create!(args_normal)
+        Entry.create!(args_normal)
         Account.named('Cash_11').balance.should eq(10)
         Account.named('Loan_12').balance.should eq(10)
-        Transaction.create!(args_reversed)
+        Entry.create!(args_reversed)
         Account.named('Cash_11').balance.should eq(0)
         Account.named('Loan_12').balance.should eq(0)
       end
     end
 
-    describe 'transaction_types' do
-      it 'should create a Transaction with a TransactionType of Unassigned if none is passed in' do
-        t = Transaction.build(
-          description: 'spec transaction 01',
+    describe 'entry_types' do
+      it 'should create a Entry with a EntryType of Unassigned if none is passed in' do
+        t = Entry.build(
+          description: 'spec entry 01',
           debits:  [{account: 'Cash_11', amount: 10}],
           credits: [{account: 'Loan_12', amount:  9},
                     {account: 'Loan_12', amount:  1}])
-        t.transaction_type.description.should eq('unassigned')
+        t.entry_type.description.should eq('unassigned')
       end
 
-      it 'should create a Transaction with a TransactionType of Unassigned if none is passed in' do
-        TransactionType.create!(description: 'donation')
-        t = Transaction.build(
-          description: 'spec transaction 01',
-          transaction_type: TransactionType.of(:donation),
+      it 'should create a Entry with a EntryType of Unassigned if none is passed in' do
+        EntryType.create!(description: 'donation')
+        t = Entry.build(
+          description: 'spec entry 01',
+          entry_type: EntryType.of(:donation),
           debits:  [{account: 'Cash_11', amount: 10}],
           credits: [{account: 'Loan_12', amount:  9},
                     {account: 'Loan_12', amount:  1}])
-        t.transaction_type.description.should eq('donation')
+        t.entry_type.description.should eq('donation')
       end
     end
 
-    describe 'transaction_types, when multiple types exist together' do
-      it 'should segment based on transaction type' do
+    describe 'entry_types, when multiple types exist together' do
+      it 'should segment based on entry type' do
         DoubleDouble::Liability.create!(name:'hotdogs', number: 1015)
         DoubleDouble::Liability.create!(name:'junk',    number: 1016)
-        TransactionType.create!(description: 'ketchup')
-        TransactionType.create!(description: 'onions')
-        Transaction.create!(
+        EntryType.create!(description: 'ketchup')
+        EntryType.create!(description: 'onions')
+        Entry.create!(
           description: 'processed ketchup',
-          transaction_type: TransactionType.of(:ketchup),
+          entry_type: EntryType.of(:ketchup),
           debits:  [{account: 'junk',    amount: 60, context: @campaign1, accountee: @user1}], 
           credits: [{account: 'hotdogs', amount: 60, context: @campaign1, accountee: @user1}])
-        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, transaction_type: TransactionType.of(:ketchup)}).should == 60
-        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, transaction_type: TransactionType.of(:onions)}).should == 0
-        Transaction.create!(
+        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, entry_type: EntryType.of(:ketchup)}).should == 60
+        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, entry_type: EntryType.of(:onions)}).should == 0
+        Entry.create!(
           description: 'processed onions',
-          transaction_type: TransactionType.of(:onions),
+          entry_type: EntryType.of(:onions),
           debits:  [{account: 'junk',    amount: 5, context: @campaign1, accountee: @user1}], 
           credits: [{account: 'hotdogs', amount: 5, context: @campaign1, accountee: @user1}])
-        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, transaction_type: TransactionType.of(:ketchup)}).should == 60
-        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, transaction_type: TransactionType.of(:onions)}).should == 5
+        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, entry_type: EntryType.of(:ketchup)}).should == 60
+        DoubleDouble::Account.named('hotdogs').credits_balance({context: @campaign1, accountee: @user1, entry_type: EntryType.of(:onions)}).should == 5
       end
     end
 
     describe 'amount accountee references' do
-      it 'should allow a Transaction to be built describing the accountee in the hash' do
-        Transaction.create!(
+      it 'should allow a Entry to be built describing the accountee in the hash' do
+        Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'Cash_11', amount: 60, context: @campaign1, accountee: @user1},
                     {account: 'Cash_11', amount: 40, context: @campaign2, accountee: @user1},
@@ -198,8 +198,8 @@ module DoubleDouble
     end
 
     describe 'amount context references' do
-      it 'should allow a Transaction to be built describing the context in the hash' do
-        Transaction.create!(
+      it 'should allow a Entry to be built describing the context in the hash' do
+        Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'Cash_11', amount: 60, context: @campaign1},
                     {account: 'Cash_11', amount: 40, context: @campaign2}], 

--- a/spec/models/transaction_type_spec.rb
+++ b/spec/models/transaction_type_spec.rb
@@ -1,30 +1,30 @@
 module DoubleDouble
-  describe TransactionType do
+  describe EntryType do
 
-    it 'should create a TransactionType using the create! method' do
+    it 'should create a EntryType using the create! method' do
       -> {
-        TransactionType.create!(description: '123456')
-      }.should change(DoubleDouble::TransactionType, :count).by(1)
+        EntryType.create!(description: '123456')
+      }.should change(DoubleDouble::EntryType, :count).by(1)
     end
 
     it 'should not be valid without a description' do
       -> {
-        TransactionType.create!(description: '')
+        EntryType.create!(description: '')
       }.should raise_error(ActiveRecord::RecordInvalid)
-      t = TransactionType.new(description: '')
+      t = EntryType.new(description: '')
       t.should_not be_valid
     end
 
     it 'should not be valid without a long-enough description' do
       -> {
-        TransactionType.create!(description: '12345')
+        EntryType.create!(description: '12345')
       }.should raise_error(ActiveRecord::RecordInvalid)
-      t = TransactionType.new(description: '12345')
+      t = EntryType.new(description: '12345')
       t.should_not be_valid
     end
 
     it 'should return the description as the to_s method' do
-      t = TransactionType.create!(description: 'foobarbaz')
+      t = EntryType.create!(description: 'foobarbaz')
       t.to_s.should == t.description
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,25 +17,25 @@ ActiveRecord::Migration.verbose = false
     end
     add_index :double_double_accounts, [:name, :type]
 
-    create_table :double_double_transactions do |t|
+    create_table :double_double_entries do |t|
       t.string :description
       t.references :initiator,        polymorphic: true
-      t.references :transaction_type
+      t.references :entry_type
       t.timestamps
     end
-    add_index :double_double_transactions, :initiator_id
-    add_index :double_double_transactions, :initiator_type
-    add_index :double_double_transactions, :transaction_type_id
+    add_index :double_double_entries, :initiator_id
+    add_index :double_double_entries, :initiator_type
+    add_index :double_double_entries, :entry_type_id
 
-    create_table :double_double_transaction_types do |t|
+    create_table :double_double_entry_types do |t|
       t.string :description,    null: false
     end
-    add_index :double_double_transaction_types, :description
+    add_index :double_double_entry_types, :description
 
     create_table :double_double_amounts do |t|
       t.string :type
       t.references :account
-      t.references :transaction
+      t.references :entry
       t.references :context,    polymorphic: true
       t.references :subcontext, polymorphic: true
       t.references :accountee,  polymorphic: true
@@ -50,8 +50,8 @@ ActiveRecord::Migration.verbose = false
     add_index :double_double_amounts, :accountee_id
     add_index :double_double_amounts, :accountee_type
     add_index :double_double_amounts, :type
-    add_index :double_double_amounts, [:account_id, :transaction_id]
-    add_index :double_double_amounts, [:transaction_id, :account_id]
+    add_index :double_double_amounts, [:account_id, :entry_id]
+    add_index :double_double_amounts, [:entry_id, :account_id]
   end
 end
 @migration.new.migrate(:up)

--- a/spec/support/all_account_types.rb
+++ b/spec/support/all_account_types.rb
@@ -31,20 +31,20 @@ shared_examples "all account types" do
       account.should_not be_valid
     end
 
-    it "should respond_to credit_transactions" do
+    it "should respond_to credit_entries" do
       account = DoubleDouble.const_get(@capitalized_account_type).create!(name: 'acct', number: 999)
-      account.should respond_to(:credit_transactions)
+      account.should respond_to(:credit_entries)
     end
 
-    it "should respond_to debit_transactions" do
+    it "should respond_to debit_entries" do
       account = DoubleDouble.const_get(@capitalized_account_type).create!(name: 'acct', number: 999)
-      account.should respond_to(:debit_transactions)
+      account.should respond_to(:debit_entries)
     end
 
     it "a contra account should be capable of balancing against a non-contra account" do
       DoubleDouble.const_get(@capitalized_account_type).create!(name: 'acct1', number: 1)
       DoubleDouble.const_get(@capitalized_account_type).create!(name: 'acct2', number: 2, contra: true)
-      DoubleDouble::Transaction.create!(
+      DoubleDouble::Entry.create!(
         description: 
           'testing contra balancing',
         debits:[

--- a/spec/support/normal_credit_account_types.rb
+++ b/spec/support/normal_credit_account_types.rb
@@ -11,7 +11,7 @@ shared_examples "a normal credit account type" do
       end
     
       it "should report a NEGATIVE balance when an account is debited" do
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct1', amount: Money.new(75)}], 
           credits: [{account: 'acct2_contra', amount: Money.new(75)}])
@@ -20,7 +20,7 @@ shared_examples "a normal credit account type" do
       end
 
       it "should report a POSITIVE balance when an account is credited" do
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct2_contra', amount: Money.new(75)}], 
           credits: [{account: 'acct1', amount: Money.new(75)}])
@@ -29,8 +29,8 @@ shared_examples "a normal credit account type" do
       end
 
       it "should report a POSITIVE balance across the account type when CREDITED
-       and using an unrelated type for the balanced side transaction" do
-        DoubleDouble::Transaction.create!(
+       and using an unrelated type for the balanced side entry" do
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'other_account', amount: Money.new(50)}], 
           credits: [{account: 'acct1', amount: Money.new(50)}])
@@ -40,8 +40,8 @@ shared_examples "a normal credit account type" do
       end
 
       it "should report a NEGATIVE balance across the account type when DEBITED
-       and using an unrelated type for the balanced side transaction" do
-        DoubleDouble::Transaction.create!(
+       and using an unrelated type for the balanced side entry" do
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct1', amount: Money.new(50)}], 
           credits: [{account: 'other_account', amount: Money.new(50)}])
@@ -64,53 +64,53 @@ shared_examples "a normal credit account type" do
         @project1 = FactoryGirl.create(normal_credit_account_type)
         @invoice555 = FactoryGirl.create(normal_credit_account_type)
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'other_account', amount: Money.new(a1)}], 
           credits: [{account: 'acct1',         amount: Money.new(a1), context: @project1}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a2)}], 
           credits: [{account: 'acct1',         amount: Money.new(a2), context: @project1}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a3)}], 
           credits: [{account: 'acct1',         amount: Money.new(a3), context: @invoice555}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a3)}], 
           credits: [{account: 'acct1',         amount: Money.new(a3)}])
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a4), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a4)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a2), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a2)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a3), context: @invoice555}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a3)}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a4), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a4)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a2), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a2)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a3), context: @invoice555}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a3)}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])

--- a/spec/support/normal_debit_account_types.rb
+++ b/spec/support/normal_debit_account_types.rb
@@ -11,42 +11,42 @@ shared_examples "a normal debit account type" do
       end
     
       it "should report a POSITIVE balance when an account is DEBITED" do
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct1', amount: Money.new(75)}], 
           credits: [{account: 'acct2_contra', amount: Money.new(75)}])
-        @acct1.balance.should        > 0
-        @acct2_contra.balance.should > 0
+        @acct1.balance.cents.should        > 0
+        @acct2_contra.balance.cents.should > 0
       end
 
       it "should report a NEGATIVE balance when an account is CREDITED" do
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct2_contra', amount: Money.new(75)}], 
           credits: [{account: 'acct1', amount: Money.new(75)}])
-        @acct1.balance.should        < 0
-        @acct2_contra.balance.should < 0
+        @acct1.balance.cents.should        < 0
+        @acct2_contra.balance.cents.should < 0
       end
 
       it "should report a NEGATIVE balance across the account type when CREDITED
-       and using an unrelated type for the balanced side transaction" do
-        DoubleDouble::Transaction.create!(
+       and using an unrelated type for the balanced side entry" do
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'other_account', amount: Money.new(50)}], 
           credits: [{account: 'acct1', amount: Money.new(50)}])
         DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).should respond_to(:balance)
-        DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.should < 0
+        DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.cents.should < 0
         DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.should be_kind_of(Money)
       end
 
       it "should report a POSITIVE balance across the account type when DEBITED
-       and using an unrelated type for the balanced side transaction" do
-        DoubleDouble::Transaction.create!(
+       and using an unrelated type for the balanced side entry" do
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'acct1', amount: Money.new(50)}], 
           credits: [{account: 'other_account', amount: Money.new(50)}])
         DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).should respond_to(:balance)
-        DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.should > 0
+        DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.cents.should > 0
         DoubleDouble.const_get(normal_debit_account_type.to_s.capitalize).balance.should be_kind_of(Money)
       end
     end
@@ -64,53 +64,53 @@ shared_examples "a normal debit account type" do
         @project1 = FactoryGirl.create(normal_debit_account_type)
         @invoice555 = FactoryGirl.create(normal_debit_account_type)
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold some widgets',
           debits:  [{account: 'other_account', amount: Money.new(a1)}], 
           credits: [{account: 'acct1',         amount: Money.new(a1), context: @project1}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a2)}], 
           credits: [{account: 'acct1',         amount: Money.new(a2), context: @project1}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a3)}], 
           credits: [{account: 'acct1',         amount: Money.new(a3), context: @invoice555}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'other_account', amount: Money.new(a3)}], 
           credits: [{account: 'acct1',         amount: Money.new(a3)}])
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a4), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a4)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a2), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a2)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a3), context: @invoice555}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct1',         amount: Money.new(a3)}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
 
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a4), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a4)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a2), context: @project1}], 
           credits: [{account: 'other_account', amount: Money.new(a2)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a3), context: @invoice555}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])
-        DoubleDouble::Transaction.create!(
+        DoubleDouble::Entry.create!(
           description: 'Sold something',
           debits:  [{account: 'acct2',         amount: Money.new(a3)}], 
           credits: [{account: 'other_account', amount: Money.new(a3)}])

--- a/spec/support/readme_scenarios.rb
+++ b/spec/support/readme_scenarios.rb
@@ -5,8 +5,8 @@ shared_examples "it can run the README scenarios" do
       DoubleDouble::Asset.create! name:'Cash', number: 11
       DoubleDouble::Liability.create! name:'Grandpa Loan', number: 12
       DoubleDouble::Expense.create! name:'Spending', number: 13
-      # Grandpa was kind enough to loan us $800 USD in cash for college textbooks.  To enter this we will require a transaction which will affect both 'Cash' and 'Grandpa Loan'
-      DoubleDouble::Transaction.create!(
+      # Grandpa was kind enough to loan us $800 USD in cash for college textbooks.  To enter this we will require a entry which will affect both 'Cash' and 'Grandpa Loan'
+      DoubleDouble::Entry.create!(
         description: 
           'We received a loan from Grandpa',
         debits:[
@@ -14,7 +14,7 @@ shared_examples "it can run the README scenarios" do
         credits:[
           {account: 'Grandpa Loan', amount: '$800'}])
       # We buy our college textbooks.  Luckily we had more than enough.
-      DoubleDouble::Transaction.create!(
+      DoubleDouble::Entry.create!(
         description: 
           'Purchase textbooks from bookstore',
         debits:[
@@ -24,7 +24,7 @@ shared_examples "it can run the README scenarios" do
       # How much cash is left?
       DoubleDouble::Account.named('Cash').balance.to_s.should eq("320.00")
       # We deceided that we wanted to return $320 of the loan.
-      DoubleDouble::Transaction.create!(
+      DoubleDouble::Entry.create!(
         description: 
           'Payed back $320 to Grandpa',
         debits:[


### PR DESCRIPTION
- Renamed Entry to Transaction
- Changed use of Money gem in most cases to not use string parsing (monetise gem is included for that feature)
- Workaround for composed_of.
- etc.